### PR TITLE
Update to sum to mirror Enurmerable#sum, fixes issue in rails 3.2.2

### DIFF
--- a/lib/descriptive-statistics/central-tendency.rb
+++ b/lib/descriptive-statistics/central-tendency.rb
@@ -1,7 +1,11 @@
 class DescriptiveStatistics
   module CentralTendency
-    def sum
-      inject(0, :+)
+    def sum(identity = 0, &block)
+      if block_given?
+        map(&block).sum(identity)
+      else
+        inject(:+) || identity
+      end
     end
 
     def mean


### PR DESCRIPTION
This is a fix for the issue I raised earlier. It simply overwrites the sum method with the same code that the Enumerable#sum method in rails 3.2.2 uses.

Ive tested this (very very briefly) in 1.8.7 and 1.9.3 but haven't time to test it elsewhere so my apologies for that.

Hope this helps at any rate.
