### PR TITLE
pre-compute mean for speed

### DIFF
--- a/lib/descriptive-statistics/shape.rb
+++ b/lib/descriptive-statistics/shape.rb
@@ -16,7 +16,8 @@ module DescriptiveStatistics
   private
 
     def sum_cubed_deviation
-      inject(0) {|sum, value| sum + (value - mean) ** 3}
+      precalculated_mean = mean
+      inject(0) {|sum, value| sum + (value - precalculated_mean) ** 3}
     end
 
     def cubed_standard_deviation
@@ -24,7 +25,8 @@ module DescriptiveStatistics
     end
 
     def sum_quarted_deviation
-      inject(0) {|sum, value| sum + (value - mean) ** 4}
+      precalculated_mean = mean
+      inject(0) {|sum, value| sum + (value - precalculated_mean) ** 4}
     end
 
     def quarted_standard_deviation

--- a/lib/descriptive-statistics/spread.rb
+++ b/lib/descriptive-statistics/spread.rb
@@ -2,13 +2,15 @@ module DescriptiveStatistics
   module Spread
     def variance
       return if length < 1
-      sum = self.inject(0) {|accumulator, value| accumulator + (value - mean) ** 2 }
+      precalculated_mean = mean
+      sum = self.inject(0) {|accumulator, value| accumulator + (value - precalculated_mean) ** 2 }
       sum / (length.to_f - 1)
     end
 
     def population_variance
       return if length < 1
-      sum = self.inject(0) {|accumulator, value| accumulator + (value - mean) ** 2 }
+      precalculated_mean = mean
+      sum = self.inject(0) {|accumulator, value| accumulator + (value - precalculated_mean) ** 2 }
       sum / length.to_f
     end
 
@@ -19,7 +21,8 @@ module DescriptiveStatistics
 
     def relative_standard_deviation
       return if length < 1
-      (population_standard_deviation / mean) * 100.0
+      precalculated_mean = mean
+      (population_standard_deviation / precalculated_mean) * 100.0
     end
 
     def population_standard_deviation


### PR DESCRIPTION
When working with large data sets some of the more complex statistics were calculating the mean of the set multiple times per data point.  Instead, the mean could be pre-computed outside the block.
